### PR TITLE
Bugfix: Fix select masks feature when using both A and B

### DIFF
--- a/scripts/ddetailer.py
+++ b/scripts/ddetailer.py
@@ -1,3 +1,4 @@
+import gc
 import os
 import re
 import sys

--- a/scripts/ddetailer.py
+++ b/scripts/ddetailer.py
@@ -1952,7 +1952,7 @@ class MuDetectionDetailerScript(scripts.Script):
                     dd_preprocess_b, dd_bitwise_op,
                     dd_model_b, dd_classes_b,
                     dd_conf_b, dd_max_per_img_b,
-                    dd_detect_order_b, dd_select_masks_a,
+                    dd_detect_order_b, dd_select_masks_b,
                     dd_dilation_factor_b,
                     dd_offset_x_b, dd_offset_y_b,
                     dd_prompt_2, dd_neg_prompt_2,


### PR DESCRIPTION
I noticed an issue when trying to use the select masks feature when using both A and B where the selection for B was being overwritten with the selection for A. I tracked this down to a place where dd_select_masks_a was being passed in where dd_select_masks_b was expected. While doing so, I noticed that the `gc` module was being called in a function named `clear_model_cache` but was never being imported so I added an import for the gc module as well.